### PR TITLE
cli_logging: Use log level from args

### DIFF
--- a/cli_logging.py
+++ b/cli_logging.py
@@ -33,11 +33,6 @@ def handle_logging(args):
             f"log level given: {args.log}"
             f" -- must be one of: {' | '.join(levels.keys())}"
         )
-    if level is None:
-        raise ValueError(
-            f"log level given: {args.log}"
-            f" -- must be one of: {' | '.join(levels.keys())}"
-        )
     LOG_FORMAT = "%(asctime)s:%(levelname)s:%(name)s: %(message)s"
     logging.basicConfig(level=level, format=LOG_FORMAT)
 

--- a/cli_logging.py
+++ b/cli_logging.py
@@ -39,7 +39,7 @@ def handle_logging(args):
             f" -- must be one of: {' | '.join(levels.keys())}"
         )
     LOG_FORMAT = "%(asctime)s:%(levelname)s:%(name)s: %(message)s"
-    logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
+    logging.basicConfig(level=level, format=LOG_FORMAT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hey Ryan,

Thanks for the useful and concise snippets.

I stumbled across what I think is a bug in the `cli_logging` module.

[EDIT: I also removed the duplicate lines at the `None` check for `level`]

Cheers,
Georgios